### PR TITLE
Fix OpenAPI schema parsing issues

### DIFF
--- a/docs/openapi.yml
+++ b/docs/openapi.yml
@@ -6,14 +6,15 @@ info:
   contact:
     email: cjgrady@ku.edu
     name: CJ Grady
+    url: http://www.lifemapper.org/
   license:
     name: GPL 3
     url: 'https://www.gnu.org/licenses/gpl-3.0.txt'
 servers:
-  - url: 'https://syftorium.org/api/v1/'
-    description: Base URL for Syftorium services
-  - url: 'https://notyeti-195.lifemapper.org/api/v1/'
+  - url: 'https://notyeti-195.lifemapper.org/api/v1'
     description: Dev server
+  - url: 'https://syftorium.org/api/v1'
+    description: Base URL for Syftorium services
 paths:
 #  /data_cleaning:
 #    summary: Endpoint for data cleaning services
@@ -70,7 +71,11 @@ paths:
       summary: Add new identifier entries into the resolver
       operationId: resolver.post
       requestBody:
-        $ref: '#/components/requestBodies/resolver_post'
+        description: Identifier records to be added to the resolver
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/resolver_post'
       responses:
         204:
           description: Successfully accepted data for inclusion in the resolver
@@ -119,8 +124,15 @@ paths:
       description: POST a new collection to the Specify cache
       operationId: sp_cache.colection.post
       requestBody:
-        $ref: '#/components/requestBodies/new_collection'
-
+        description: Information about a new collection to add to the cache
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/new_collection_post'
+            examples:
+              example_new_collection:
+                $ref: '#/components/examples/example_new_collection'
+        required: true
       responses:
         200:
           description: A brief summary of the collection in the cache
@@ -165,7 +177,15 @@ paths:
       description: ''
       operationId: sp_cache.collection.collection_id.put
       requestBody:
-        $ref: '#/components/requestBodies/new_collection'
+        description: Information about a new collection to add to the cache
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/new_collection_post'
+            examples:
+              example_new_collection:
+                $ref: '#/components/examples/example_new_collection'
+        required: true
       responses:
         204:
           description: Collection information updated successfully
@@ -201,7 +221,12 @@ paths:
       description: ''
       operationId: sp_cache.collection.collection_id.occurrences.post
       requestBody:
-        $ref: '#/components/requestBodies/cache_data_post'
+        description: A set of occurrence records to add to the cache
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
       responses:
         204:
           description: Successfully accepted data for inclusion in the cache
@@ -216,7 +241,12 @@ paths:
       description: ''
       operationId: sp_cache.collection.collection_id.occurrences.put
       requestBody:
-        $ref: '#/components/requestBodies/cache_data_post'
+        description: A set of occurrence records to add to the cache
+        content:
+          application/zip:
+            schema:
+              type: string
+              format: binary
       responses:
         204:
           description: Successfully accepted data for inclusion in the cache
@@ -256,7 +286,11 @@ paths:
       summary: PUT an occurrence record from a collection's cache
       operationId: sp_cache.collection.collection_id.occurrences.identifier.put
       requestBody:
-        $ref: '#/components/requestBodies/update_cache_occurrence_record'
+        description: Updated data that should replace existing cached occurrence record
+        content:
+          application/json:
+            schema:
+              type: object
       responses:
         204:
           description: Successfully updated the record
@@ -287,57 +321,24 @@ components:
       name: X-API-Key
   examples:
     example_new_collection:
-      value: |-
-        {
-          "collection_name": "Fish Tissue Collection",
-          "institution_name": "University of Kansas",
-          "collection_id": "ku_fish_tissue",
-          "collection_location": "Lawrence, Kansas USA",
-          "contact_email": "fish_collection@example.com",
-          "contact_name": "Fish Contact",
-          "public_key": "COLLECTION PUBLIC KEY"
-        }
+      value:
+        collection_name: Fish Tissue Collection
+        institution_name: University of Kansas
+        collection_id: ku_fish_tissue
+        collection_location: 'Lawrence, Kansas USA'
+        contact_email: fish_collection@example.com
+        contact_name: Fish Contact
+        public_key: COLLECTION PUBLIC KEY
+
     simple_collection_status:
-      value: |-
-        {
-          "collection_name": "Fish Tissue Collection",
-          "institution_name": "University of Kansas",
-          "collection_id": "ku_fish_tissue",
-          "collection_location": "Lawrence, Kansas USA",
-          "contact_email": "fish_collection@example.com",
-          "contact_name": "Fish Contact",
-          "record_count": 23423
-        }
-  requestBodies:
-    cache_data_post:
-      description: A set of occurrence records to add to the cache
-      content:
-        application/zip:
-          schema:
-            type: string
-            format: binary
-    new_collection:
-      description: Information about a new collection to add to the cache
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/new_collection_post'
-          examples:
-            example_new_collection:
-              $ref: '#/components/examples/example_new_collection'
-      required: true
-    resolver_post:
-      description: Identifier records to be added to the resolver
-      content:
-        application/json:
-          schema:
-            $ref: '#/components/schemas/resolver_post'
-    update_cache_occurrence_record:
-      description: Updated data that should replace existing cached occurrence record
-      content:
-        application/json:
-          schema:
-            type: object
+      value:
+        collection_name: Fish Tissue Collection
+        institution_name: University of Kansas
+        collection_id: ku_fish_tissue
+        collection_location: 'Lawrence, Kansas USA'
+        contact_email: fish_collection@example.com
+        contact_name: Fish Contact
+        record_count: 23423
 
   schemas:
     collection_status:


### PR DESCRIPTION
Even though this schema is valid, the Python OpenAPI validator does not support all of the OpenAPI keywords